### PR TITLE
Changes to fire a delegate method when the dialog is dismissed

### DIFF
--- a/OAuthiOS/Src/OAuthIOModal.h
+++ b/OAuthiOS/Src/OAuthIOModal.h
@@ -28,6 +28,7 @@
 - (void)didReceiveOAuthIOCode:(NSString *)code;
 - (void)didAuthenticateServerSide:(NSString *)body andResponse:(NSURLResponse *) response;
 - (void)didFailAuthenticationServerSide:(NSString *)body andResponse:(NSURLResponse *)response andError:(NSError *)error;
+- (void)didDismissModalDialog;
 @end
 
 @interface OAuthIOModal : UIViewController<UIWebViewDelegate>

--- a/OAuthiOS/Src/OAuthIOModal.m
+++ b/OAuthiOS/Src/OAuthIOModal.m
@@ -396,6 +396,7 @@ NSString *_host;
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
     [_rootViewController presentViewController:self animated:YES completion:^{
+
         [_browser loadRequest:url];
     }];
 }
@@ -442,7 +443,11 @@ NSString *_host;
     {
         if ([url.scheme isEqual:@"oauthio"] && [url.host isEqual:@"localhost"])
         {
-            [self dismissViewControllerAnimated:YES completion:nil];
+            [self dismissViewControllerAnimated:YES completion:^(){
+                if([self.delegate respondsToSelector:@selector(didDismissModalDialog)]) {
+                    [self.delegate didDismissModalDialog];
+                }
+            }];
             [self getTokens:[url absoluteString]];
             return (NO);
         }


### PR DESCRIPTION
Add a delegate method to call on callback of dismissViewControllerAnimated. This allows the user to wait for the animation to finish before firing other animations or changing other view controller attributes.